### PR TITLE
Add sdp m_line_index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "mashumaro~=3.13",
     "orjson>=3.10.7",
 ]
-version = "0.0.0"
+version = "0.3.0"
 
 [project.urls]
 "Homepage"    = "https://pypi.org/project/webrtc-models"

--- a/tests/__snapshots__/test_init.ambr
+++ b/tests/__snapshots__/test_init.ambr
@@ -38,11 +38,13 @@
 # name: test_decoding_and_encoding[RTCIceCandidate-RTCIceCandidate_candidate.json][dataclass]
   dict({
     'candidate': '3932168448 1 udp 1694498815 1.2.3.4 10676 typ srflx raddr 0.0.0.0 rport 37566',
+    'sdp_m_line_index': 0,
   })
 # ---
 # name: test_decoding_and_encoding[RTCIceCandidate-RTCIceCandidate_end.json][dataclass]
   dict({
     'candidate': '',
+    'sdp_m_line_index': 0,
   })
 # ---
 # name: test_decoding_and_encoding[RTCIceServer-RTCIceServer_only_urls_list.json][dataclass]

--- a/tests/fixtures/RTCIceCandidate_candidate.json
+++ b/tests/fixtures/RTCIceCandidate_candidate.json
@@ -1,3 +1,4 @@
 {
-  "candidate": "3932168448 1 udp 1694498815 1.2.3.4 10676 typ srflx raddr 0.0.0.0 rport 37566"
+  "candidate": "3932168448 1 udp 1694498815 1.2.3.4 10676 typ srflx raddr 0.0.0.0 rport 37566",
+  "sdp_m_line_index": 0
 }

--- a/tests/fixtures/RTCIceCandidate_end.json
+++ b/tests/fixtures/RTCIceCandidate_end.json
@@ -1,3 +1,4 @@
 {
-  "candidate": ""
+  "candidate": "",
+  "sdp_m_line_index": 0
 }

--- a/uv.lock
+++ b/uv.lock
@@ -383,7 +383,7 @@ wheels = [
 
 [[package]]
 name = "webrtc-models"
-version = "0.0.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "mashumaro" },

--- a/webrtc_models/__init__.py
+++ b/webrtc_models/__init__.py
@@ -56,3 +56,4 @@ class RTCIceCandidate(_RTCBaseModel):
     """
 
     candidate: str
+    sdp_m_line_index: int


### PR DESCRIPTION
# Proposed Changes

Add sdp_m_line_index field to RtcIceCandidate. Either this field or the sdpMId is required to correctly assign Ice candidates to the correct `m=` line. This PR assumes we'll always use the line index for simplicity.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
